### PR TITLE
Fix manifest filename case

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,13 +2,13 @@
   "manifest_version": 3,
   "name": "Joking Jira",
   "description": "Fix some frustrating Jira behaviors",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "options_ui": {
-    "page": "ConfigurationPopUp.html"
+    "page": "configurationPopUp.html"
   },
   "action": {
     "default_icon": "icon-128.png",
-    "default_popup": "ConfigurationPopUp.html"
+    "default_popup": "configurationPopUp.html"
   },
   "content_scripts": [
       {


### PR DESCRIPTION
Avoid this error when installing

![image](https://github.com/user-attachments/assets/7cb88bf4-7456-4470-9b50-484ab016f3d2)